### PR TITLE
Fix docs Tailwind source path

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -15,4 +15,8 @@
   color: var(--color-fd-primary);
 }
 
-@source '../node_modules/fumadocs-ui/dist/**/*.js';
+/*
+ * Point Tailwind's @source directive to the workspace-level `node_modules`
+ * folder so that Fumadocs UI classes are discovered correctly.
+ */
+@source '../../../node_modules/fumadocs-ui/dist/**/*.js';


### PR DESCRIPTION
## Summary
- update Tailwind `@source` path in docs
- rebuild docs site

## Testing
- `bun run --cwd apps/docs build`
- `npm test` *(fails: ENCRYPTION_KEY not set, Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_686be8289bc483248d350ca1bb3989ba