### PR TITLE
Fix docs stylesheet path

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -20,4 +20,4 @@
  * folder so that Fumadocs UI classes are discovered correctly.
  */
 
-@source '../../../../node_modules/fumadocs-ui/dist/**/*.js'
+@source '../node_modules/fumadocs-ui/dist/**/*.js'


### PR DESCRIPTION
## Summary
- correct source path for fumadocs-ui in docs global stylesheet

## Testing
- `CI=1 bun install`
- `bun run build` in `apps/docs`


------
https://chatgpt.com/codex/tasks/task_e_686c12f3d3648324b1bbf4f445061472